### PR TITLE
Fix #74: Always use absolute displacement for rip-relative memory operands

### DIFF
--- a/src/tests/tests/tests.decoder.cpp
+++ b/src/tests/tests/tests.decoder.cpp
@@ -5,7 +5,7 @@
 
 namespace zasm::tests
 {
-    TEST(DecoderTests, DecodeToAssembler)
+    TEST(DecoderTests, DecodeToAssembler01)
     {
         Program program(MachineMode::AMD64);
         Decoder decoder(MachineMode::AMD64);
@@ -18,10 +18,10 @@ namespace zasm::tests
 
         auto decoded = decoder.decode(inputBytes.data(), inputBytes.size(), 0x00400000);
         ASSERT_TRUE(decoded);
-        
+
         ASSERT_EQ(decoded->getMnemonic(), x86::Mnemonic::Mov);
         ASSERT_EQ(decoded->getOperandCount(), 2);
-        
+
         ASSERT_EQ(assembler.emit(decoded.value()), Error::None);
 
         Serializer serializer;
@@ -31,7 +31,45 @@ namespace zasm::tests
             0xB8, 0x01, 0x00, 0x00, 0x00,
         };
         ASSERT_EQ(serializer.getCodeSize(), expected.size());
-        
+
+        const auto* data = serializer.getCode();
+        ASSERT_NE(data, nullptr);
+        for (size_t i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(data[i], expected[i]);
+        }
+    }
+
+    TEST(DecoderTests, Regression_74)
+    {
+        Program program(MachineMode::AMD64);
+        Decoder decoder(MachineMode::AMD64);
+
+        x86::Assembler assembler(program);
+
+        const std::array<uint8_t, 6> inputBytes = {
+            0xFF, 0x15, 0x73, 0x16, 0x00, 0x00, // CALL QWORD PTR DS:[0x00007FF8833E0679]
+        };
+
+        auto decoded = decoder.decode(inputBytes.data(), inputBytes.size(), 0x00007FF8833DF000);
+        ASSERT_TRUE(decoded);
+
+        ASSERT_EQ(decoded->getMnemonic(), x86::Mnemonic::Call);
+        ASSERT_EQ(decoded->getExplicitOperandCount(), 1);
+        ASSERT_EQ(decoded->getOperandCount(), 4);
+        ASSERT_EQ(decoded->getOperand<Mem>(0).getBase(), x86::rip);
+        ASSERT_EQ(decoded->getOperand<Mem>(0).getDisplacement(), 0x00007FF8833E0679);
+
+        ASSERT_EQ(assembler.emit(decoded.value()), Error::None);
+
+        Serializer serializer;
+        ASSERT_EQ(serializer.serialize(program, 0x00007FF8833DF000), Error::None);
+
+        const std::array<uint8_t, 6> expected = {
+            0xFF, 0x15, 0x73, 0x16, 0x00, 0x00,
+        };
+        ASSERT_EQ(serializer.getCodeSize(), expected.size());
+
         const auto* data = serializer.getCode();
         ASSERT_NE(data, nullptr);
         for (size_t i = 0; i < expected.size(); i++)

--- a/src/zasm/src/decoder/decoder.cpp
+++ b/src/zasm/src/decoder/decoder.cpp
@@ -36,7 +36,7 @@ namespace zasm
             if (isRipRelative(srcOp.mem))
             {
                 // Keep RIP as a hint to make this relative.
-                disp += instr.length + address;
+                disp += static_cast<std::int64_t>(address + instr.length);
             }
             return Mem{ toBitSize(srcOp.size),   getReg(srcOp.mem.segment), baseReg,
                         getReg(srcOp.mem.index), srcOp.mem.scale,           disp };

--- a/src/zasm/src/encoder/encoder.cpp
+++ b/src/zasm/src/encoder/encoder.cpp
@@ -359,13 +359,21 @@ namespace zasm
         {
             // We require the exact instruction size to encode this correctly.
             const auto instrSize = ctx != nullptr ? ctx->instrSize : 0;
-            if (ctx != nullptr && instrSize == 0)
+            if (instrSize == 0)
             {
-                // Causes to re-encode again with instruction size available.
-                ctx->instrSize = kHintRequiresSize;
+                if (ctx != nullptr)
+                {
+                    // Causes to re-encode again with instruction size available.
+                    ctx->instrSize = kHintRequiresSize;
+                }
+                
+                // Ensure this encodes.
+                displacement = kTemporaryRel32Value;
             }
-
-            displacement = displacement - (address + instrSize);
+            else
+            {
+                displacement = displacement - (address + instrSize);
+            }
 
             if (externalLabel)
             {

--- a/src/zasm/src/encoder/generator.cpp
+++ b/src/zasm/src/encoder/generator.cpp
@@ -88,14 +88,12 @@ namespace zasm
             else if (const auto* opMem = opSrc.getIf<Mem>(); opMem != nullptr && opDecoded.holds<Mem>())
             {
                 const auto& opDecodedMem = opDecoded.get<Mem>();
-                // We only require to modify the memory operand if there is a label or has a different segment.
-                if (opMem->hasLabel() || opMem->getSegment() != opDecodedMem.getSegment())
-                {
-                    // Create copy of input operand in order to modify it.
-                    Mem mem = *opMem;
-                    mem.setSegment(opDecodedMem.getSegment());
-                    newInstr.setOperand(i, mem);
-                }
+
+                // Create copy of input operand in order to modify it.
+                Mem mem = *opMem;
+                mem.setSegment(opDecodedMem.getSegment());
+                    
+                newInstr.setOperand(i, mem);
             }
             else if (opSrc.holds<Imm>())
             {


### PR DESCRIPTION
Closes #74 