### PR TITLE
Fix OOB read in serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /src/.vs
 .vscode/
 build*/
-
+.idea/**

--- a/src/tests/tests/tests.serialization.cpp
+++ b/src/tests/tests/tests.serialization.cpp
@@ -1036,4 +1036,57 @@ namespace zasm::tests
         ASSERT_EQ(serializer.getLabelAddress(label01.getId()), 0x0000000000401020);
     }
 
+    TEST(SerializationTests, SerializeDecodedSwapNodes)
+    {
+        zasm::Program program(zasm::MachineMode::I386);
+        std::vector<zasm::Node*> tails = {};
+
+        {
+            zasm::x86::Assembler a(program);
+            zasm::Decoder decoder(zasm::MachineMode::I386);
+
+            const std::array<uint8_t, 12> raw_data = {
+                0xB8, 0x00, 0x10, 0x40, 0x00, // mov eax, [blabla]
+                0x83, 0xF8, 0x00,             // cmp eax, 0
+                0x90,                         // nop
+                0xEB, 0x00,                   // jmp short $+2
+                0xC3                          // ret
+            };
+            const uintptr_t addr = 0x401030;
+
+            size_t offset = 0;
+            while (offset < raw_data.size())
+            {
+                auto v = decoder.decode(raw_data.data() + offset, std::min(15ull, raw_data.size() - offset), addr + offset);
+                a.emit(v->getInstruction());
+                tails.emplace_back(program.getTail());
+                offset += v->getLength();
+            }
+        }
+        ASSERT_EQ(tails.size(), 5);
+
+        auto label = program.createLabel();
+        auto bind_node = program.bindLabel(label);
+        program.moveBefore(tails[4], *bind_node);
+
+        tails[3]->getIf<zasm::Instruction>()->setOperand(0, label);
+
+        zasm::x86::Assembler a(program);
+        a.setCursor(tails[4]);
+        a.xor_(zasm::x86::eax, zasm::x86::eax);
+
+        zasm::Serializer serializer{};
+        auto r = serializer.serialize(program, 0x406000);
+        ASSERT_EQ(r, zasm::Error::None);
+
+        const std::array<std::uint8_t, 14> expected = { 0xB8, 0x00, 0x10, 0x40, 0x00, 0x83, 0xF8,
+                                                        0x00, 0x90, 0xEB, 0x00, 0xC3, 0x31, 0xC0 };
+        const auto* data = serializer.getCode();
+        ASSERT_NE(data, nullptr);
+        ASSERT_EQ(serializer.getCodeSize(), expected.size());
+        for (std::size_t i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(data[i], expected[i]);
+        }
+    }
 } // namespace zasm::tests

--- a/src/tests/tests/tests.serialization.cpp
+++ b/src/tests/tests/tests.serialization.cpp
@@ -1057,7 +1057,7 @@ namespace zasm::tests
             size_t offset = 0;
             while (offset < raw_data.size())
             {
-                auto v = decoder.decode(raw_data.data() + offset, std::min(15ull, raw_data.size() - offset), addr + offset);
+                auto v = decoder.decode(raw_data.data() + offset, raw_data.size() - offset, addr + offset);
                 a.emit(v->getInstruction());
                 tails.emplace_back(program.getTail());
                 offset += v->getLength();

--- a/src/zasm/src/serialization/serializer.cpp
+++ b/src/zasm/src/serialization/serializer.cpp
@@ -160,6 +160,11 @@ namespace zasm
             return res.error();
         }
 
+        if (ctx.nodeIndex >= ctx.nodes.size())
+        {
+            return Error::OutOfBounds;
+        }
+
         {
             auto& nodeEntry = ctx.nodes[ctx.nodeIndex];
             ctx.nodeIndex++;
@@ -459,12 +464,7 @@ namespace zasm
         const auto* lastNode = last != nullptr ? last->getNext() : nullptr;
 
         const auto nodeCount = [&]() noexcept -> size_t {
-            // If the entire program is serialized the size is known.
-            if (first == program.getHead() && last == program.getTail())
-            {
-                return program.size();
-            }
-            // else count nodes in range.
+            // Count nodes in range.
             std::size_t count = 0;
             for (const auto* node = first; node != lastNode; node = node->getNext())
             {


### PR DESCRIPTION
Hello. I just found a very edge ~~(and cursed)~~ case where the serializer would try to access the OOB node within the `serializeNode` function. I implemented a test case for it and fixed the issue.

Here are the benchmark results before and after my changes were made:

<details> 
  <summary>Before</summary>
  
```diff
Running Release\zasm_benchmarks.exe
Run on (24 X 3693 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 512 KiB (x12)
  L3 Unified 32768 KiB (x2)

Benchmark                                   Time             CPU   Iterations UserCounters...
BM_Assembler_EmitSingle_0_Operands       20.0 us         18.5 us       179200 Instructions=54.0981k/s
BM_Assembler_EmitSingle_1_Operands       16.2 us         14.9 us       165926 Instructions=67.2105k/s
BM_Assembler_EmitSingle_2_Operands       16.3 us         13.7 us       165926 Instructions=73.2363k/s
BM_Assembler_EmitSingle_3_Operands       21.8 us         20.1 us       186667 Instructions=49.7779k/s
BM_Assembler_EmitAll                     2.02 ms         1.66 ms          640 Instructions=6.08557M/s
BM_Formatter_Program                      119 ms         96.0 ms            7 PrintedNodes=10.3154M/s
BM_InstructionInfo                       13.4 ms         10.9 ms           50 InstructionInfos=923.703k/s
BM_SerializationBasic                    2.00 ms         1.73 ms          640 BytesEncoded=41.7771M/s Instructions=5.82843M/s
BM_SerializationWithLabels<128>          1.99 ms         1.63 ms          345 BytesEncoded=44.4153M/s Instructions=6.19651M/s
BM_SerializationWithLabels<64>           2.00 ms         1.76 ms          560 BytesEncoded=41.5397M/s Instructions=5.74748M/s
BM_SerializationWithLabels<32>           2.10 ms         1.85 ms          448 BytesEncoded=40.154M/s Instructions=5.46553M/s
BM_StringPool_Aquire/0                   7.44 ns         6.70 ns    112000000
BM_StringPool_Aquire/1                   7.31 ns         6.41 ns    100000000
BM_StringPool_Aquire/2                   10.5 ns         9.77 ns     64000000
BM_StringPool_Aquire/3                   13.3 ns         13.1 ns     56000000
BM_StringPool_Aquire/4                   17.7 ns         15.0 ns     44800000
BM_StringPool_Release/0                   277 ns          244 ns      2240000
BM_StringPool_Release/1                   277 ns          218 ns      3733333
BM_StringPool_Release/2                   277 ns          275 ns      3521123
BM_StringPool_Release/3                   277 ns          278 ns      3200000
BM_StringPool_Release/4                   277 ns          258 ns      2357895
BM_StringPool_Get/0                       275 ns          285 ns      2800000
BM_StringPool_Get/1                       273 ns          235 ns      2986667
BM_StringPool_Get/2                       275 ns          224 ns      2508800
BM_StringPool_Get/3                       276 ns          229 ns      3200000
BM_StringPool_Get/4                       274 ns          270 ns      2488889
BM_StringPool_GetLength/0                 276 ns          227 ns      3446154
BM_StringPool_GetLength/1                 275 ns          257 ns      2488889
BM_StringPool_GetLength/2                 275 ns          232 ns      2357895
BM_StringPool_GetLength/3                 275 ns          244 ns      3200000
BM_StringPool_GetLength/4                 276 ns          272 ns      2986667
```
</details>

<details> 
  <summary>After</summary>
  
```diff
Running Release\zasm_benchmarks.exe
Run on (24 X 3693 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 512 KiB (x12)
  L3 Unified 32768 KiB (x2)
  
Benchmark                                   Time             CPU   Iterations UserCounters...
BM_Assembler_EmitSingle_0_Operands       22.0 us         18.9 us       186667 Instructions=52.8615k/s
BM_Assembler_EmitSingle_1_Operands       16.1 us         13.8 us       165926 Instructions=72.2399k/s
BM_Assembler_EmitSingle_2_Operands       26.2 us         22.5 us       203636 Instructions=44.4802k/s
BM_Assembler_EmitSingle_3_Operands       20.0 us         18.7 us       179200 Instructions=53.3433k/s
BM_Assembler_EmitAll                     2.97 ms         2.69 ms         1120 Instructions=3.75224M/s
BM_Formatter_Program                      120 ms          107 ms            7 PrintedNodes=9.24088M/s
BM_InstructionInfo                       13.0 ms         8.90 ms           93 InstructionInfos=1.13459M/s
BM_SerializationBasic                    2.07 ms         1.63 ms          498 BytesEncoded=44.3856M/s Instructions=6.19236M/s
BM_SerializationWithLabels<128>          2.08 ms         1.76 ms          560 BytesEncoded=41.1968M/s Instructions=5.74748M/s
BM_SerializationWithLabels<64>           2.11 ms         1.38 ms          407 BytesEncoded=52.8333M/s Instructions=7.31008M/s
BM_SerializationWithLabels<32>           2.19 ms         1.71 ms          320 BytesEncoded=43.4319M/s Instructions=5.9117M/s
BM_StringPool_Aquire/0                   7.40 ns         6.72 ns    100000000
BM_StringPool_Aquire/1                   7.52 ns         5.94 ns    100000000
BM_StringPool_Aquire/2                   11.0 ns         8.88 ns     80929032
BM_StringPool_Aquire/3                   13.6 ns         10.1 ns     89600000
BM_StringPool_Aquire/4                   18.2 ns         16.1 ns     40727273
BM_StringPool_Release/0                   280 ns          213 ns      3446154
BM_StringPool_Release/1                   284 ns          245 ns      3446154
BM_StringPool_Release/2                   280 ns          259 ns      3200000
BM_StringPool_Release/3                   282 ns          261 ns      4072727
BM_StringPool_Release/4                   279 ns          229 ns      3200000
BM_StringPool_Get/0                       276 ns          190 ns      2800000
BM_StringPool_Get/1                       283 ns          206 ns      2800000
BM_StringPool_Get/2                       286 ns          279 ns      2800000
BM_StringPool_Get/3                       278 ns          207 ns      2488889
BM_StringPool_Get/4                       283 ns          173 ns      3345067
BM_StringPool_GetLength/0                 279 ns          235 ns      2986667
BM_StringPool_GetLength/1                 280 ns          246 ns      2800000
BM_StringPool_GetLength/2                 278 ns          258 ns      2357895
BM_StringPool_GetLength/3                 280 ns          209 ns      2986667
BM_StringPool_GetLength/4                 281 ns          238 ns      3145831
```
</details>

But i am still a bit concerned about the perf degradation because each time it serializes something, it eventually iterates over all nodes multiple times, and, whenever it serializes a node it also checks if we're OOB. \
As for the bounds check it's pretty much just a couple more asm instructions, but iterating all node trees multiple times per serialization sounds like a really bad idea.