### PR TITLE
Add overload for memory operand to allow rip relative constants

### DIFF
--- a/include/zasm/x86/memory.hpp
+++ b/include/zasm/x86/memory.hpp
@@ -14,7 +14,7 @@ namespace zasm::x86
     {
         return Mem(bitSize, Seg{}, base, {}, 0, 0);
     }
-    
+
     // ptr [base + disp]
     // ex.: mov eax, ptr [edx+0xC]
     static constexpr Mem ptr(BitSize bitSize, const Gp& base, int64_t disp) noexcept
@@ -56,7 +56,14 @@ namespace zasm::x86
     {
         return Mem(bitSize, Seg{}, base, rip, Reg{}, 0, 0);
     }
-    
+
+    // ptr [rel address]
+    // ex.: mov eax, ptr [rel 0x00400000]
+    static constexpr Mem ptr(BitSize bitSize, const Rip& rip, int64_t disp) noexcept
+    {
+        return Mem(bitSize, Seg{}, Label{}, rip, Reg{}, 0, disp);
+    }
+
     // ptr [rel label + disp]
     // ex.: mov eax, ptr [rel label+0xC]
     static constexpr Mem ptr(BitSize bitSize, const Rip& rip, const Label& base, int64_t disp) noexcept
@@ -84,11 +91,10 @@ namespace zasm::x86
     {
         return Mem(bitSize, seg, base, {}, 0, disp);
     }
-    
+
     // ptr : seg [base + index]
     // ex.: mov eax, ptr:ds [edx+ecx]
-    static constexpr Mem ptr(
-        BitSize bitSize, const Seg& seg, const Gp& base, const Gp& index) noexcept
+    static constexpr Mem ptr(BitSize bitSize, const Seg& seg, const Gp& base, const Gp& index) noexcept
     {
         return Mem(bitSize, seg, base, index, 0, 0);
     }
@@ -100,28 +106,28 @@ namespace zasm::x86
     {
         return Mem(bitSize, seg, base, index, scale, disp);
     }
-    
+
     // ptr : seg [label + disp]
     // ex.: mov eax, ptr:ds [label+0xC]
     static constexpr Mem ptr(BitSize bitSize, const Seg& seg, const Label& base, int64_t disp) noexcept
     {
         return Mem(bitSize, seg, base, Reg{}, Reg{}, 0, disp);
     }
-    
+
     // ptr : seg [rel label]
     // ex.: mov eax, ptr:ds [rel label]
     static constexpr Mem ptr(BitSize bitSize, const Seg& seg, const Rip& rip, const Label& base) noexcept
     {
         return Mem(bitSize, seg, base, rip, Reg{}, 0, 0);
     }
-    
+
     // ptr : seg [rel label + disp]
     // ex.: mov eax, ptr:ds [rel label+0xC]
     static constexpr Mem ptr(BitSize bitSize, const Seg& seg, const Rip& rip, const Label& base, int64_t disp) noexcept
     {
         return Mem(bitSize, seg, base, rip, Reg{}, 0, disp);
     }
-    
+
     // ptr : seg [disp]
     // ex.: mov eax, ptr:fs [0]
     static constexpr Mem ptr(BitSize bitSize, const Seg& seg, int64_t disp) noexcept

--- a/src/tests/tests/tests.serialization.cpp
+++ b/src/tests/tests/tests.serialization.cpp
@@ -1090,4 +1090,31 @@ namespace zasm::tests
         }
     }
 
+    TEST(SerializationTests, EncodeRipRelAddress)
+    {
+        Program program(MachineMode::AMD64);
+
+        x86::Assembler assembler(program);
+
+        auto reg = x86::rdx;
+        auto address = (uint64_t)0x0000000000401000;
+
+        ASSERT_EQ(assembler.mov(x86::Gp64(reg.getId()), x86::qword_ptr(x86::rip, (uintptr_t)address)), Error::None);
+
+        Serializer serializer;
+        ASSERT_EQ(serializer.serialize(program, 0x0000000000401000), Error::None);
+
+        const std::array<std::uint8_t, 7> expected = {
+            0x48, 0x8B, 0x15, 0xF9, 0xFF, 0xFF, 0xFF
+        };
+        ASSERT_EQ(serializer.getCodeSize(), expected.size());
+
+        const auto* data = serializer.getCode();
+        ASSERT_NE(data, nullptr);
+        for (std::size_t i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(data[i], expected[i]);
+        }
+    }
+
 } // namespace zasm::tests


### PR DESCRIPTION
Allows to do
```cpp
a.mov(x86::rax, x86::qword_ptr(x86::rip, 0x00400000));
```