### PR TITLE
Setting mode member of Filestream class

### DIFF
--- a/src/zasm/src/core/filestream.cpp
+++ b/src/zasm/src/core/filestream.cpp
@@ -107,6 +107,7 @@ namespace zasm
         _state->length = offset();
         seek(0, SeekType::Begin);
 
+        _state->mode = mode;
         return Error::None;
     }
 


### PR DESCRIPTION
We have method mode() which returns open mode of current file but we never set mode variable.Thus it always return None.It seems that it simply was forgotten