### PR TITLE
Fix #124: memory scale defaulting to 0 rather than 1 when index is supplied

### DIFF
--- a/include/zasm/x86/memory.hpp
+++ b/include/zasm/x86/memory.hpp
@@ -26,7 +26,7 @@ namespace zasm::x86
     // ex.: mov eax, ptr [ecx+edx]
     static constexpr Mem ptr(BitSize bitSize, const Gp& base, const Gp& index) noexcept
     {
-        return Mem(bitSize, Seg{}, base, index, 0, 0);
+        return Mem(bitSize, Seg{}, base, index, 1, 0);
     }
 
     // ptr [base + index * scale + disp]
@@ -96,7 +96,7 @@ namespace zasm::x86
     // ex.: mov eax, ptr:ds [edx+ecx]
     static constexpr Mem ptr(BitSize bitSize, const Seg& seg, const Gp& base, const Gp& index) noexcept
     {
-        return Mem(bitSize, seg, base, index, 0, 0);
+        return Mem(bitSize, seg, base, index, 1, 0);
     }
 
     // ptr : seg [base + index * scale + disp]

--- a/src/tests/tests/tests.serialization.cpp
+++ b/src/tests/tests/tests.serialization.cpp
@@ -1104,9 +1104,7 @@ namespace zasm::tests
         Serializer serializer;
         ASSERT_EQ(serializer.serialize(program, 0x0000000000401000), Error::None);
 
-        const std::array<std::uint8_t, 7> expected = {
-            0x48, 0x8B, 0x15, 0xF9, 0xFF, 0xFF, 0xFF
-        };
+        const std::array<std::uint8_t, 7> expected = { 0x48, 0x8B, 0x15, 0xF9, 0xFF, 0xFF, 0xFF };
         ASSERT_EQ(serializer.getCodeSize(), expected.size());
 
         const auto* data = serializer.getCode();
@@ -1190,6 +1188,27 @@ namespace zasm::tests
         }
 
         ASSERT_EQ(serializer.getLabelAddress(label.getId()), 0x140015000 + 13);
+    }
+
+    TEST(SerializationTests, TestMemBaseIndex)
+    {
+        Program program(MachineMode::AMD64);
+
+        x86::Assembler a(program);
+        ASSERT_EQ(a.mov(x86::rax, x86::qword_ptr(x86::rax, x86::rbp)), Error::None);
+
+        Serializer serializer;
+        ASSERT_EQ(serializer.serialize(program, 0x140015000), Error::None);
+
+        const std::array<uint8_t, 4> expected = { 0x48, 0x8B, 0x04, 0x28 };
+        ASSERT_EQ(serializer.getCodeSize(), expected.size());
+
+        const auto* data = serializer.getCode();
+        ASSERT_NE(data, nullptr);
+        for (std::size_t i = 0; i < expected.size(); i++)
+        {
+            ASSERT_EQ(data[i], expected[i]);
+        }
     }
 
 } // namespace zasm::tests


### PR DESCRIPTION
Closes #124