### PR TITLE
Add missing cstdlib include

### DIFF
--- a/zasm/src/zasm/src/formatter/formatter.cpp
+++ b/zasm/src/zasm/src/formatter/formatter.cpp
@@ -4,6 +4,7 @@
 #include <cinttypes>
 #include <cmath>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <zasm/base/register.hpp>
 #include <zasm/formatter/formatter.hpp>


### PR DESCRIPTION
std::malloc, std::realloc and std::free are provided by cstdlib